### PR TITLE
Update activerecord-postgres_enum.gemspec

### DIFF
--- a/activerecord-postgres_enum.gemspec
+++ b/activerecord-postgres_enum.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.5"
 
-  spec.add_runtime_dependency "activerecord", ">= 5", "< 6.1"
+  spec.add_runtime_dependency "activerecord", ">= 5", "< 7"
   spec.add_runtime_dependency "pg"
 
   spec.add_development_dependency "appraisal", "~> 2.2"


### PR DESCRIPTION
Allow Rails 6.1 in gemspec